### PR TITLE
server name as bytes

### DIFF
--- a/protobuf/protos/steammessages_gameservers.steamclient.proto
+++ b/protobuf/protos/steammessages_gameservers.steamclient.proto
@@ -14,7 +14,7 @@ message CGameServers_GetServerList_Response {
 		optional uint32 gameport = 2;
 		optional uint32 specport = 3;
 		optional fixed64 steamid = 4;
-		optional string name = 5;
+		optional bytes name = 5;
 		optional uint32 appid = 6;
 		optional string gamedir = 7;
 		optional string version = 8;

--- a/protobuf/src/generated/steammessages_gameservers_steamclient.rs
+++ b/protobuf/src/generated/steammessages_gameservers_steamclient.rs
@@ -291,7 +291,7 @@ pub mod cgame_servers_get_server_list_response {
         // @@protoc_insertion_point(field:CGameServers_GetServerList_Response.Server.steamid)
         pub steamid: ::std::option::Option<u64>,
         // @@protoc_insertion_point(field:CGameServers_GetServerList_Response.Server.name)
-        pub name: ::std::option::Option<::std::string::String>,
+        pub name: ::std::option::Option<::std::vec::Vec<u8>>,
         // @@protoc_insertion_point(field:CGameServers_GetServerList_Response.Server.appid)
         pub appid: ::std::option::Option<u32>,
         // @@protoc_insertion_point(field:CGameServers_GetServerList_Response.Server.gamedir)
@@ -427,12 +427,12 @@ pub mod cgame_servers_get_server_list_response {
             self.steamid = ::std::option::Option::Some(v);
         }
 
-        // optional string name = 5;
+        // optional bytes name = 5;
 
-        pub fn name(&self) -> &str {
+        pub fn name(&self) -> &[u8] {
             match self.name.as_ref() {
                 Some(v) => v,
-                None => "",
+                None => &[],
             }
         }
 
@@ -445,22 +445,22 @@ pub mod cgame_servers_get_server_list_response {
         }
 
         // Param is passed by value, moved
-        pub fn set_name(&mut self, v: ::std::string::String) {
+        pub fn set_name(&mut self, v: ::std::vec::Vec<u8>) {
             self.name = ::std::option::Option::Some(v);
         }
 
         // Mutable pointer to the field.
         // If field is not initialized, it is initialized with default value first.
-        pub fn mut_name(&mut self) -> &mut ::std::string::String {
+        pub fn mut_name(&mut self) -> &mut ::std::vec::Vec<u8> {
             if self.name.is_none() {
-                self.name = ::std::option::Option::Some(::std::string::String::new());
+                self.name = ::std::option::Option::Some(::std::vec::Vec::new());
             }
             self.name.as_mut().unwrap()
         }
 
         // Take field
-        pub fn take_name(&mut self) -> ::std::string::String {
-            self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        pub fn take_name(&mut self) -> ::std::vec::Vec<u8> {
+            self.name.take().unwrap_or_else(|| ::std::vec::Vec::new())
         }
 
         // optional uint32 appid = 6;
@@ -836,7 +836,7 @@ pub mod cgame_servers_get_server_list_response {
                         self.steamid = ::std::option::Option::Some(is.read_fixed64()?);
                     },
                     42 => {
-                        self.name = ::std::option::Option::Some(is.read_string()?);
+                        self.name = ::std::option::Option::Some(is.read_bytes()?);
                     },
                     48 => {
                         self.appid = ::std::option::Option::Some(is.read_uint32()?);
@@ -902,7 +902,7 @@ pub mod cgame_servers_get_server_list_response {
                 my_size += 1 + 8;
             }
             if let Some(v) = self.name.as_ref() {
-                my_size += ::protobuf::rt::string_size(5, &v);
+                my_size += ::protobuf::rt::bytes_size(5, &v);
             }
             if let Some(v) = self.appid {
                 my_size += ::protobuf::rt::uint32_size(6, v);
@@ -962,7 +962,7 @@ pub mod cgame_servers_get_server_list_response {
                 os.write_fixed64(4, v)?;
             }
             if let Some(v) = self.name.as_ref() {
-                os.write_string(5, v)?;
+                os.write_bytes(5, v)?;
             }
             if let Some(v) = self.appid {
                 os.write_uint32(6, v)?;


### PR DESCRIPTION
if you try to read the list of dayz servers using the string type, you'll get a shitty utf8 conversion error