### PR TITLE
Add some useful session values

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use filter::MessageFilter;
 use futures_util::future::{select, Either};
 use futures_util::{FutureExt, Sink, SinkExt};
 use std::future::Future;
+use std::net::IpAddr;
 use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -161,6 +162,22 @@ impl Connection {
 
     pub fn steam_id(&self) -> SteamID {
         self.session.steam_id
+    }
+
+    pub fn session_id(&self) -> i32 {
+        self.session.session_id
+    }
+
+    pub fn cell_id(&self) -> u32 {
+        self.session.cell_id
+    }
+
+    pub fn public_ip(&self) -> Option<IpAddr> {
+        self.session.public_ip
+    }
+
+    pub fn ip_country_code(&self) -> Option<String> {
+        self.session.ip_country_code.clone()
     }
 
     pub(crate) async fn raw_send<Msg: NetMessage>(


### PR DESCRIPTION
While working on data retrieval from CDN servers, I needed an optimal `cell_id`, but it was hidden. I also implemented a few other useful ones that are already implemented into SteamKit2