### PR TITLE
fix reconnect panic

### DIFF
--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -21,7 +21,7 @@ pub async fn connect(
 )> {
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
-        .expect("failed to setup crypto provider");
+        .ok(); // can only be once called
     let mut root_store = RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let mut tls_config = ClientConfig::builder()


### PR DESCRIPTION
Reconnect always panics because `install_default` and preceding methods don't return any errors, except when the static object is already created. This is also mentioned in the [documentation](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default)