### PR TITLE
Correctly handle jobs that can have multiple responses

### DIFF
--- a/protobuf/common/src/lib.rs
+++ b/protobuf/common/src/lib.rs
@@ -84,3 +84,9 @@ impl<T: MsgKindEnum> PartialEq<T> for MsgKind {
         self.0.eq(&other.enum_value())
     }
 }
+
+/// Trait for implementing a check for completion of a job that returns a response stream
+pub trait JobMultiple {
+    /// If the job has completed
+    fn completed(&self) -> bool;
+}

--- a/protobuf/steam/src/lib.rs
+++ b/protobuf/steam/src/lib.rs
@@ -1,3 +1,11 @@
 mod generated;
 
 pub use generated::*;
+
+impl steam_vent_proto_common::JobMultiple
+    for steammessages_clientserver_appinfo::CMsgClientPICSProductInfoResponse
+{
+    fn completed(&self) -> bool {
+        !self.response_pending.unwrap_or(false)
+    }
+}


### PR DESCRIPTION
Some jobs can have multiple responses (such as `CMsgClientPICSProductInfoResponse` with its `response_pending` field). This commit handles this. I am not entirely happy with the code as it somewhat breaks the barrier between what `Filter` and `ConnectionTrait` are supposed to handle, but I'm not sure a better solution exists within the current architecture. 

The result/error type is also up for debate - we should probably return partially anyway even if there was an error, and let the user decide if they want it or not. Maybe we also want to return a `broadcast::Receiver` instead?

As a reference, see for example: https://github.com/SteamRE/SteamKit/blob/b4e4cb929b55c45bf262ab2b293be2424f81975a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs#L178

I guess this could be expanded to collect the data into a reasonable structure, but this would seem more suited to a high-level wrapper:
https://github.com/SteamRE/SteamKit/blob/master/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs#L629