### PR TITLE
Improvements to server picking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,6 +1727,7 @@ dependencies = [
  "num-traits 0.2.19",
  "num_enum",
  "protobuf",
+ "rand",
  "reqwest",
  "rsa",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ num_enum = "0.7.3"
 directories = "5.0.1"
 another-steam-totp = "0.3.3"
 async-stream = "0.3.5"
+rand = "0.8.5"
 
 [dev-dependencies]
 tokio = { version = "1.39", features = ["macros", "rt", "rt-multi-thread"] }

--- a/examples/backpack.rs
+++ b/examples/backpack.rs
@@ -1,10 +1,11 @@
 use std::env::args;
+use std::error::Error;
 use std::io::Cursor;
 use steam_vent::auth::{
     AuthConfirmationHandler, ConsoleAuthConfirmationHandler, DeviceConfirmationHandler,
     FileGuardDataStore,
 };
-use steam_vent::{Connection, ConnectionError, ConnectionTrait, GameCoordinator, ServerList};
+use steam_vent::{Connection, ConnectionTrait, GameCoordinator, ServerList};
 use steam_vent_proto::tf2::base_gcmessages::CSOEconItem;
 use steam_vent_proto::tf2::gcsdk_gcmessages::{
     CMsgSOCacheSubscribed, CMsgSOCacheSubscriptionRefresh,
@@ -12,7 +13,7 @@ use steam_vent_proto::tf2::gcsdk_gcmessages::{
 use steam_vent_proto::RpcMessage;
 
 #[tokio::main]
-async fn main() -> Result<(), ConnectionError> {
+async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 
     let mut args = args().skip(1);

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -1,4 +1,5 @@
 use std::env::args;
+use std::error::Error;
 use std::io::stdin;
 use steam_vent::auth::{
     AuthConfirmationHandler, ConsoleAuthConfirmationHandler, DeviceConfirmationHandler,
@@ -7,7 +8,7 @@ use steam_vent::auth::{
 use steam_vent::proto::steammessages_friendmessages_steamclient::{
     CFriendMessages_IncomingMessage_Notification, CFriendMessages_SendMessage_Request,
 };
-use steam_vent::{Connection, ConnectionError, ConnectionTrait, ServerList};
+use steam_vent::{Connection, ConnectionTrait, ServerList};
 use steam_vent_proto::enums::EPersonaStateFlag;
 use steam_vent_proto::steammessages_clientserver_friends::CMsgClientChangeStatus;
 use steamid_ng::SteamID;
@@ -15,7 +16,7 @@ use tokio::spawn;
 use tokio_stream::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<(), ConnectionError> {
+async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 
     let mut args = args().skip(1);

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -1,13 +1,14 @@
 use std::env::args;
+use std::error::Error;
 use steam_vent::auth::{
     AuthConfirmationHandler, ConsoleAuthConfirmationHandler, DeviceConfirmationHandler,
     FileGuardDataStore,
 };
 use steam_vent::proto::steammessages_player_steamclient::CPlayer_GetOwnedGames_Request;
-use steam_vent::{Connection, ConnectionError, ConnectionTrait, ServerList};
+use steam_vent::{Connection, ConnectionTrait, ServerList};
 
 #[tokio::main]
-async fn main() -> Result<(), ConnectionError> {
+async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 
     let mut args = args().skip(1);

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,8 +1,9 @@
+use std::error::Error;
 use steam_vent::proto::steammessages_gameservers_steamclient::CGameServers_GetServerList_Request;
-use steam_vent::{Connection, ConnectionError, ConnectionTrait, ServerList};
+use steam_vent::{Connection, ConnectionTrait, ServerList};
 
 #[tokio::main]
-async fn main() -> Result<(), ConnectionError> {
+async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 
     let server_list = ServerList::discover().await?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,6 @@ use crate::proto::steammessages_base::CMsgIPAddress;
 use crate::proto::steammessages_clientserver_login::{
     CMsgClientHello, CMsgClientLogon, CMsgClientLogonResponse,
 };
-use crate::serverlist::ServerDiscoveryError;
 use protobuf::MessageField;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -27,8 +26,6 @@ pub enum ConnectionError {
     Network(#[from] NetworkError),
     #[error("Login failed: {0:#}")]
     LoginError(#[from] LoginError),
-    #[error(transparent)]
-    Discovery(#[from] ServerDiscoveryError),
     #[error("Aborted")]
     Aborted,
     #[error("Unsupported confirmation action")]


### PR DESCRIPTION
- Cycled iterator over random shuffled server list
- Ensure that WS servers were returned also, to avoid a panic in `pick_ws`
- Remove `From<DiscoveryError>` for the `ConnectionError` enum as it was only used in examples and breaks the intended separation of concerns

This is partially in preparation for some reconnect logic as described in #20 , but also just to solve some of your TODOs :)