### PR TITLE
More flexible auth

### DIFF
--- a/examples/web_cookie.rs
+++ b/examples/web_cookie.rs
@@ -1,0 +1,40 @@
+use std::env::args;
+use std::error::Error;
+use steam_vent::{
+    auth::{
+        AuthConfirmationHandler, AuthData, ConsoleAuthConfirmationHandler,
+        DeviceConfirmationHandler, StartedAuth,
+    },
+    Connection, ServerList,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt::init();
+
+    let mut args = args().skip(1);
+    let account = args.next().expect("no account");
+    let password = args.next().expect("no password");
+
+    let server_list = ServerList::discover().await?;
+    let mut connection = Connection::connect(&server_list).await?;
+    let auth =
+        StartedAuth::begin_via_credentials(&connection, AuthData::new(&account, &password)).await?;
+    let tokens = auth
+        .wait_confirmation(
+            &connection,
+            ConsoleAuthConfirmationHandler::default().or(DeviceConfirmationHandler),
+        )
+        .await?;
+    connection
+        .login_with_token(&account, &tokens.refresh_token, auth.steam_id())
+        .await?;
+
+    // if necessary
+    // connection.setup_heartbeat();
+
+    println!("access token: {}", tokens.access_token);
+    println!("refresh token: {}", tokens.refresh_token);
+
+    Ok(())
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -102,7 +102,7 @@ impl StartedAuth {
         let encoded_password = BASE64_STANDARD.encode(encrypted_password);
         info!(data.account, "starting credentials login");
         let req = CAuthentication_BeginAuthSessionViaCredentials_Request {
-            account_name: Some(data.account.into()),
+            account_name: Some(data.account),
             encrypted_password: Some(encoded_password),
             encryption_timestamp: Some(timestamp),
             persistence: Some(EnumOrUnknown::new(if data.is_persistent {
@@ -206,13 +206,13 @@ impl StartedAuth {
         let allowed_confirmations = self.allowed_confirmations();
         let tokens = match select(
             pin!(confirmation_handler.handle_confirmation(&allowed_confirmations)),
-            pin!(self.poll().wait_for_tokens(&connection)),
+            pin!(self.poll().wait_for_tokens(connection)),
         )
         .await
         {
             Either::Left((confirmation_action, tokens_fut)) => {
                 if let Some(confirmation_action) = confirmation_action {
-                    self.submit_confirmation(&connection, confirmation_action)
+                    self.submit_confirmation(connection, confirmation_action)
                         .await?;
                     tokens_fut.await?
                 } else if self.action_required() {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -31,6 +31,7 @@ use thiserror::Error;
 use tokio::time::sleep;
 use tracing::{debug, error, info, instrument};
 
+#[derive(Debug, Clone)]
 pub struct AuthData {
     pub account: String,
     pub password: String,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -119,6 +119,12 @@ impl Connection {
             .wait_confirmation(&connection, confirmation_handler)
             .await?;
 
+        if let Some(guard_data) = tokens.new_guard_data {
+            if let Err(e) = guard_data_store.store(account, guard_data).await {
+                error!(error = ?e, "failed to store guard data");
+            }
+        }
+
         connection.session = login(
             &mut connection,
             account,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,6 +1,6 @@
 mod filter;
 
-use crate::auth::{begin_password_auth, AuthConfirmationHandler, GuardDataStore};
+use crate::auth::{AuthConfirmationHandler, AuthData, GuardDataStore, StartedAuth};
 use crate::message::{NetMessage, ServiceMethodMessage, ServiceMethodResponseMessage};
 use crate::net::{NetMessageHeader, NetworkError, RawNetMessage};
 use crate::proto::enums_clientserver::EMsg;
@@ -11,12 +11,10 @@ use crate::session::{anonymous, hello, login, ConnectionError, Session};
 use crate::transport::websocket::connect;
 use async_stream::try_stream;
 pub use filter::MessageFilter;
-use futures_util::future::{select, Either};
 use futures_util::{FutureExt, Sink, SinkExt};
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::net::IpAddr;
-use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 use steam_vent_proto::{JobMultiple, MsgKindEnum};
@@ -65,7 +63,7 @@ impl Debug for Connection {
 }
 
 impl Connection {
-    async fn connect(server_list: &ServerList) -> Result<Self, ConnectionError> {
+    pub async fn connect(server_list: &ServerList) -> Result<Self, ConnectionError> {
         let (read, write) = connect(&server_list.pick_ws()).await?;
         let filter = MessageFilter::new(read);
         let heartbeat_cancellation_token = CancellationToken::new();
@@ -115,45 +113,16 @@ impl Connection {
         if guard_data.is_some() {
             debug!(account, "found stored guard data");
         }
-        let begin =
-            begin_password_auth(&mut connection, account, password, guard_data.as_deref()).await?;
-        let steam_id = SteamID::from(begin.steam_id());
-
-        let allowed_confirmations = begin.allowed_confirmations();
-
-        let tokens = match select(
-            pin!(confirmation_handler.handle_confirmation(&allowed_confirmations)),
-            pin!(begin.poll().wait_for_tokens(&connection)),
-        )
-        .await
-        {
-            Either::Left((confirmation_action, tokens_fut)) => {
-                if let Some(confirmation_action) = confirmation_action {
-                    begin
-                        .submit_confirmation(&connection, confirmation_action)
-                        .await?;
-                    tokens_fut.await?
-                } else if begin.action_required() {
-                    return Err(ConnectionError::UnsupportedConfirmationAction(
-                        allowed_confirmations.clone(),
-                    ));
-                } else {
-                    tokens_fut.await?
-                }
-            }
-            Either::Right((tokens, _)) => tokens?,
-        };
-
-        if let Some(guard_data) = tokens.new_guard_data {
-            if let Err(e) = guard_data_store.store(account, guard_data).await {
-                error!(error = ?e, "failed to store guard data");
-            }
-        }
+        let data = AuthData::with_guard(account, password, &mut guard_data_store).await;
+        let begin = StartedAuth::begin_via_credentials(&connection, data).await?;
+        let tokens = begin
+            .wait_confirmation(&connection, confirmation_handler)
+            .await?;
 
         connection.session = login(
             &mut connection,
             account,
-            steam_id,
+            begin.steam_id(),
             // yes we send the refresh token as access token, yes it makes no sense, yes this is actually required
             tokens.refresh_token.as_ref(),
         )
@@ -163,7 +132,17 @@ impl Connection {
         Ok(connection)
     }
 
-    fn setup_heartbeat(&self) {
+    pub async fn login_with_token(
+        &mut self,
+        account: &str,
+        access_token: &str,
+        steam_id: SteamID,
+    ) -> Result<(), ConnectionError> {
+        self.session = login(self, account, steam_id, access_token).await?;
+        Ok(())
+    }
+
+    pub fn setup_heartbeat(&self) {
         let sender = self.sender.clone();
         let interval = self.session.heartbeat_interval;
         let header = NetMessageHeader {


### PR DESCRIPTION
Web auth requires tokens, which is why the auth process needs to be more flexible than it is now. Also I made `setup_heartbeat` public because sometimes one-time sessions may be required to retrieve one-time data.