### PR TITLE
fix: send correct kind for CMsgClientHello

### DIFF
--- a/src/game_coordinator.rs
+++ b/src/game_coordinator.rs
@@ -132,7 +132,8 @@ impl GameCoordinator {
             self.send_with_kind(CMsgClientHello::default(), GCMsgKind::k_EMsgGCServerHello)
                 .await?;
         } else {
-            self.send(CMsgClientHello::default()).await?;
+            self.send_with_kind(CMsgClientHello::default(), GCMsgKind::k_EMsgGCClientHello)
+                .await?;
         }
         Ok(())
     }


### PR DESCRIPTION
While experimenting with the library I noticed that the backpack example doesn't work, it got stuck at trying to connect to the gc. After alot of debugging and checking what messages were being exchanged, I noticed that the CMsgClientHello message that we send had the wrong message kind.

Instead of sending ``4006`` like expected it was sending ``9805`` which caused it to never receive the welcome message. It looks like this is caused by there existing two identical ``CMsgClientHello`` messages, one for ``9805`` and one for ``4006``?